### PR TITLE
fix: bitwidth of monpro intermediary signals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ifeq ($(SIM),ghdl)
     COM = @ghdl -a $(GHDLAFLAGS) --work=$(LIBNAME) $<
 	SYNT = ghdl --synth $(GHDLRFLAGS) --out=none $(UNIT)
 	SCHEMA = yosys -m ghdl -p \
-			"ghdl $(GHDLRFLAGS) $(UNIT); show -notitle -format dot -prefix $(TOP)/$(DIR)/$(UNIT)"
+			"ghdl $(GHDLRFLAGS) $(UNIT); show -stretch -width -format dot -prefix $(TOP)/$(DIR)/$(UNIT)"
 
     ifeq ($(GUI),yes)
         RUN = ghdl -r $(GHDLRFLAGS) $(UNIT) $(GHDLRUNOPTS) --wave=$(UNIT).ghw; \
@@ -228,9 +228,14 @@ $$($(1)-unit).synth: all
 
 $$($(1)-unit).schema: all
 	@printf '[SCHEMATIC]    %-70s\n' "$$(LIBNAME).$$(subst _tb, ,$$(UNIT))"
+	@printf '\nRemoving old .dot and .svg files\n'
+	@rm -r $$(TOP)/$$(DIR)/schema
+	@mkdir $$(TOP)/$$(DIR)/schema
 	$$(SCHEMA)
-	dot -T svg -o $$(TOP)/$$(DIR)/$$(UNIT).svg $$(TOP)/$$(DIR)/$$(UNIT).dot
-	open $$(TOP)/$$(DIR)/$$(UNIT).svg
+	dot -Tsvg -O $$(TOP)/$$(DIR)/$$(UNIT).dot
+	@mv *.svg schema/
+	@mv *.dot schema/
+	@printf '\n[SCHEMATIC]    Schematics generated in output directory\n'
 
 endef
 $(foreach f,$(SRCS),$(eval $(call GEN_rule,$(f))))

--- a/Makefile
+++ b/Makefile
@@ -229,8 +229,8 @@ $$($(1)-unit).synth: all
 $$($(1)-unit).schema: all
 	@printf '[SCHEMATIC]    %-70s\n' "$$(LIBNAME).$$(subst _tb, ,$$(UNIT))"
 	@printf '\nRemoving old .dot and .svg files\n'
-	@rm -r $$(TOP)/$$(DIR)/schema
-	@mkdir $$(TOP)/$$(DIR)/schema
+	@mkdir -p $$(TOP)/$$(DIR)/schema
+	@rm -f $$(TOP)/$$(DIR)/schema/*.svg $$(TOP)/$$(DIR)/schema/*.dot
 	$$(SCHEMA)
 	dot -Tsvg -O $$(TOP)/$$(DIR)/$$(UNIT).dot
 	@mv *.svg schema/

--- a/source/monpro/monpro.vhd
+++ b/source/monpro/monpro.vhd
@@ -55,6 +55,9 @@ architecture rtl of monpro is
   signal shiftreg_enable       : std_logic;
   signal shiftreg_shift_enable : std_logic;
 
+  -- Used during execution of algorithm
+  signal is_odd : std_logic;
+
 begin
 
   datapath : entity work.monpro_datapath(rtl)
@@ -74,7 +77,8 @@ begin
       modulus               => modulus,
       operand_a             => operand_a,
       operand_b             => operand_b,
-      result                => result
+      result                => result,
+      is_odd                => is_odd
     );
 
 end architecture rtl;

--- a/source/monpro/monpro_datapath.vhd
+++ b/source/monpro/monpro_datapath.vhd
@@ -7,7 +7,7 @@ library ieee;
 
 entity monpro_datapath is
   generic (
-    bit_width : integer := 4
+    bit_width : integer := 256
   );
   port (
     -----------------------------------------------------------------------------

--- a/source/monpro/monpro_datapath.vhd
+++ b/source/monpro/monpro_datapath.vhd
@@ -37,7 +37,12 @@ entity monpro_datapath is
     modulus   : in    std_logic_vector(bit_width - 1 downto 0);
     operand_a : in    std_logic_vector(bit_width - 1 downto 0);
     operand_b : in    std_logic_vector(bit_width - 1 downto 0);
-    result    : out   std_logic_vector(bit_width - 1 downto 0)
+    result    : out   std_logic_vector(bit_width - 1 downto 0);
+
+    -----------------------------------------------------------------------------
+    -- u(0) xor (a(i) and b(0))
+    -----------------------------------------------------------------------------
+    is_odd : out   std_logic
   );
 end entity monpro_datapath;
 
@@ -47,9 +52,8 @@ architecture rtl of monpro_datapath is
   signal and_b_a : std_logic_vector(bit_width - 1 downto 0);
 
   -- Internal registers
-  signal outreg_r     : std_logic_vector(bit_width - 1 downto 0);
-  signal shiftreg_r   : std_logic_vector(bit_width - 1 downto 0);
-  signal shiftreg_lsb : std_logic;
+  signal outreg_r   : std_logic_vector(bit_width - 1 downto 0);
+  signal shiftreg_r : std_logic_vector(bit_width - 1 downto 0);
 
   -- Output from bit shifter
   signal outreg_right_shifted : std_logic_vector(bit_width - 1 downto 0);
@@ -61,8 +65,8 @@ architecture rtl of monpro_datapath is
 
 begin
 
-  result       <= outreg_r;
-  shiftreg_lsb <= shiftreg_r(0);
+  result <= outreg_r;
+  is_odd <= outreg_r(0) xor (operand_b(0) and shiftreg_r(0));
 
   alu : entity work.alu(rtl)
     generic map (
@@ -76,7 +80,7 @@ begin
       less_than => alu_less_than
     );
 
-  alu_a_mux : entity work.mux2(rtl)
+  alu_a_mux : entity work.mux_2to1(rtl)
     generic map (
       bit_width => bit_width
     )
@@ -87,10 +91,10 @@ begin
       sel => alu_a_sel
     );
 
-  -- shiftreg_lsb and operand_b are different sizes, might be sussy
-  and_b_a <= shiftreg_lsb and operand_b;
+  -- shiftreg_r(0) and operand_b are different sizes, might be sussy
+  and_b_a <= shiftreg_r(0) and operand_b;
 
-  alu_b_mux : entity work.mux2(rtl)
+  alu_b_mux : entity work.mux_2to1(rtl)
     generic map (
       bit_width => bit_width
     )

--- a/source/monpro/monpro_datapath.vhd
+++ b/source/monpro/monpro_datapath.vhd
@@ -7,7 +7,7 @@ library ieee;
 
 entity monpro_datapath is
   generic (
-    bit_width : integer := 256
+    bit_width : integer := 4
   );
   port (
     -----------------------------------------------------------------------------
@@ -52,25 +52,26 @@ architecture rtl of monpro_datapath is
   signal and_b_a : std_logic_vector(bit_width - 1 downto 0);
 
   -- Internal registers
-  signal outreg_r   : std_logic_vector(bit_width - 1 downto 0);
+  -- Intermediary result has size bit_width+1
+  signal outreg_r   : std_logic_vector(bit_width downto 0);
   signal shiftreg_r : std_logic_vector(bit_width - 1 downto 0);
 
   -- Output from bit shifter
-  signal outreg_right_shifted : std_logic_vector(bit_width - 1 downto 0);
+  signal outreg_right_shifted : std_logic_vector(bit_width downto 0);
 
   -- ALU inputs and outputs
-  signal alu_a      : std_logic_vector(bit_width - 1 downto 0);
-  signal alu_b      : std_logic_vector(bit_width - 1 downto 0);
-  signal alu_result : std_logic_vector(bit_width - 1 downto 0);
+  signal alu_a      : std_logic_vector(bit_width downto 0);
+  signal alu_b      : std_logic_vector(bit_width downto 0);
+  signal alu_result : std_logic_vector(bit_width downto 0);
 
 begin
 
-  result <= outreg_r;
+  result <= outreg_r(bit_width - 1 downto 0);
   is_odd <= outreg_r(0) xor (operand_b(0) and shiftreg_r(0));
 
   alu : entity work.alu(rtl)
     generic map (
-      bit_width => bit_width
+      bit_width => bit_width + 1
     )
     port map (
       operand_a => alu_a,
@@ -82,7 +83,7 @@ begin
 
   alu_a_mux : entity work.mux_2to1(rtl)
     generic map (
-      bit_width => bit_width
+      bit_width => bit_width + 1
     )
     port map (
       a0  => outreg_r,
@@ -92,15 +93,15 @@ begin
     );
 
   -- shiftreg_r(0) and operand_b are different sizes, might be sussy
-  and_b_a <= shiftreg_r(0) and operand_b;
+  and_b_a <= operand_b and shiftreg_r(0);
 
   alu_b_mux : entity work.mux_2to1(rtl)
     generic map (
-      bit_width => bit_width
+      bit_width => bit_width + 1
     )
     port map (
-      a0  => modulus,
-      a1  => and_b_a,
+      a0  => '0' & modulus,
+      a1  => '0' & and_b_a,
       b   => alu_b,
       sel => alu_b_sel
     );
@@ -109,7 +110,7 @@ begin
   bit_shifter : process (outreg_r) is
   begin
 
-    outreg_right_shifted <= '0' & outreg_r(bit_width - 1 downto 1);
+    outreg_right_shifted <= '0' & outreg_r(bit_width downto 1);
 
   end process bit_shifter;
 

--- a/source/shared/mux_2to1.vhd
+++ b/source/shared/mux_2to1.vhd
@@ -1,27 +1,25 @@
 -----------------------------------------------------------------------------
--- 3:1 binary multiplexer, with variable bitwidth of signals
+-- 2:1 binary multiplexer, with variable bitwidth of signals
 ----------------------------------------------------------------------------
 
 library ieee;
   use ieee.std_logic_1164.all;
   use ieee.numeric_std.all;
 
-entity mux3 is
+entity mux_2to1 is
   generic (
     bit_width : integer := 256
   );
   port (
     a0 : in    std_logic_vector(bit_width - 1 downto 0);
     a1 : in    std_logic_vector(bit_width - 1 downto 0);
-    a2 : in    std_logic_vector(bit_width - 1 downto 0);
+    b  : out   std_logic_vector(bit_width - 1 downto 0);
 
-    b : out   std_logic_vector(bit_width - 1 downto 0);
-
-    sel : in    std_logic_vector(1 downto 0)
+    sel : in    std_logic
   );
-end entity mux3;
+end entity mux_2to1;
 
-architecture rtl of mux3 is
+architecture rtl of mux_2to1 is
 
 begin
 
@@ -30,17 +28,13 @@ begin
 
     case(sel) is
 
-      when "00" =>
+      when '0' =>
 
         b <= a0;
 
-      when "01" =>
+      when '1' =>
 
         b <= a1;
-
-      when "10" =>
-
-        b <= a2;
 
       when others =>
 

--- a/source/shared/mux_3to1.vhd
+++ b/source/shared/mux_3to1.vhd
@@ -1,25 +1,27 @@
 -----------------------------------------------------------------------------
--- 2:1 binary multiplexer, with variable bitwidth of signals
+-- 3:1 binary multiplexer, with variable bitwidth of signals
 ----------------------------------------------------------------------------
 
 library ieee;
   use ieee.std_logic_1164.all;
   use ieee.numeric_std.all;
 
-entity mux2 is
+entity mux_3to1 is
   generic (
     bit_width : integer := 256
   );
   port (
     a0 : in    std_logic_vector(bit_width - 1 downto 0);
     a1 : in    std_logic_vector(bit_width - 1 downto 0);
-    b  : out   std_logic_vector(bit_width - 1 downto 0);
+    a2 : in    std_logic_vector(bit_width - 1 downto 0);
 
-    sel : in    std_logic
+    b : out   std_logic_vector(bit_width - 1 downto 0);
+
+    sel : in    std_logic_vector(1 downto 0)
   );
-end entity mux2;
+end entity mux_3to1;
 
-architecture rtl of mux2 is
+architecture rtl of mux_3to1 is
 
 begin
 
@@ -28,13 +30,17 @@ begin
 
     case(sel) is
 
-      when '0' =>
+      when "00" =>
 
         b <= a0;
 
-      when '1' =>
+      when "01" =>
 
         b <= a1;
+
+      when "10" =>
+
+        b <= a2;
 
       when others =>
 

--- a/source/source.mk
+++ b/source/source.mk
@@ -1,3 +1,3 @@
 alu: utils
 monpro: monpro_datapath
-monpro_datapath: alu mux2
+monpro_datapath: alu mux_2to1

--- a/vhdl_ls.toml
+++ b/vhdl_ls.toml
@@ -10,5 +10,6 @@ uvvm_util.is_third_party = true
 worklib.files = [
   "source/*.vhd",
   "source/monpro/*.vhd",
+  "source/shared/*.vhd",
   "testbench/*.vhd",
 ]


### PR DESCRIPTION
- Add `is_odd` signal for use in monpro algorithm
- Increase size of intermediary register to `bit_width + 1`