### PR TITLE
feat: reduce states

### DIFF
--- a/source/modexp/modexp_control.vhd
+++ b/source/modexp/modexp_control.vhd
@@ -37,11 +37,11 @@ end entity modexp_control;
 architecture rtl of modexp_control is
 
   type state_type is (
-    waiting,                                       -- Input handshake
-    start,                                         -- Removes leading zeros from e shiftreg
-    monpro_xx, save_xx, monpro_mx, save_mx, shift, -- Repeated squaring
-    monpro_x1, save_x1,                            -- Prepare output
-    valid                                          -- Output handshake
+    waiting,                     -- Input handshake
+    start,                       -- Removes leading zeros from e shiftreg
+    monpro_xx, monpro_mx, shift, -- Repeated squaring
+    monpro_x1,                   -- Prepare output
+    valid                        -- Output handshake
   );
 
   signal state, state_next : state_type;
@@ -92,19 +92,15 @@ begin
         monpro_enable <= '1';
 
         if (monpro_output_valid = '1') then
-          state_next <= save_xx;
+          out_reg_enable <= '1';
+          monpro_enable  <= '0';
+          if (e_current_bit = '1') then
+            state_next <= monpro_mx;
+          else
+            state_next <= shift;
+          end if;
         else
           state_next <= monpro_xx;
-        end if;
-
-      when save_xx =>
-
-        out_reg_enable <= '1';
-
-        if (e_current_bit = '1') then
-          state_next <= monpro_mx;
-        else
-          state_next <= shift;
         end if;
 
       when monpro_mx =>
@@ -113,15 +109,12 @@ begin
         monpro_b_select <= "10";
 
         if (monpro_output_valid = '1') then
-          state_next <= save_mx;
+          out_reg_enable <= '1';
+          monpro_enable  <= '0';
+          state_next     <= shift;
         else
           state_next <= monpro_mx;
         end if;
-
-      when save_mx =>
-
-        out_reg_enable <= '1';
-        state_next     <= shift;
 
       when shift =>
 
@@ -139,15 +132,12 @@ begin
         monpro_b_select <= "01";
 
         if (monpro_output_valid = '1') then
-          state_next <= save_x1;
+          out_reg_enable <= '1';
+          monpro_enable  <= '0';
+          state_next     <= valid;
         else
           state_next <= monpro_x1;
         end if;
-
-      when save_x1 =>
-
-        out_reg_enable <= '1';
-        state_next     <= valid;
 
       when valid =>
 

--- a/source/modexp/modexp_control.vhd
+++ b/source/modexp/modexp_control.vhd
@@ -38,6 +38,7 @@ architecture rtl of modexp_control is
 
   type state_type is (
     waiting,                                       -- Input handshake
+    start,                                         -- Removes leading zeros from e shiftreg
     monpro_xx, save_xx, monpro_mx, save_mx, shift, -- Repeated squaring
     monpro_x1, save_x1,                            -- Prepare output
     valid                                          -- Output handshake
@@ -47,7 +48,7 @@ architecture rtl of modexp_control is
 
 begin
 
-  process (clk, reset) is
+  process (all) is
   begin
 
     in_ready               <= '0';
@@ -72,9 +73,18 @@ begin
         out_reg_in_select <= '1';
 
         if (in_valid = '1') then
-          state_next <= monpro_xx;
+          state_next <= start;
         else
           state_next <= waiting;
+        end if;
+
+      when start =>
+
+        if (e_current_bit = '1') then
+          state_next <= monpro_xx;
+        else
+          shift_reg_shift_enable <= '1';
+          state_next             <= start;
         end if;
 
       when monpro_xx =>

--- a/source/modmul/modmul_control.vhd
+++ b/source/modmul/modmul_control.vhd
@@ -1,6 +1,8 @@
 library ieee;
   use ieee.std_logic_1164.all;
   use ieee.numeric_std.all;
+
+  -- Utils
   use work.utils.all;
 
 entity modmul_control is

--- a/source/monpro/monpro.vhd
+++ b/source/monpro/monpro.vhd
@@ -56,7 +56,8 @@ architecture rtl of monpro is
   signal shift_reg_shift_enable : std_logic;
 
   -- Used during execution of algorithm
-  signal is_odd : std_logic;
+  signal is_odd        : std_logic;
+  signal n_bit_is_last : std_logic;
 
 begin
 
@@ -78,19 +79,18 @@ begin
       operand_a              => operand_a,
       operand_b              => operand_b,
       result                 => result,
-      is_odd                 => is_odd
+      is_odd                 => is_odd,
+      n_bit_is_last          => n_bit_is_last
     );
 
   control : entity work.monpro_control(rtl)
-    generic map (
-      bit_width => bit_width
-    )
     port map (
       clk                    => clk,
       reset                  => reset,
       enable                 => enable,
       alu_less_than          => alu_less_than,
       is_odd                 => is_odd,
+      n_bit_is_last          => n_bit_is_last,
       out_reg_enable         => out_reg_enable,
       shift_reg_enable       => shift_reg_enable,
       shift_reg_shift_enable => shift_reg_shift_enable,

--- a/source/monpro/monpro_datapath.vhd
+++ b/source/monpro/monpro_datapath.vhd
@@ -74,7 +74,7 @@ architecture rtl of monpro_datapath is
 begin
 
   result        <= out_reg_r(bit_width - 1 downto 0);
-  is_odd        <= out_reg_r(0) xor (operand_b(0) and a_shift_reg_r(0));
+  is_odd        <= alu_a(0) xor (operand_b(0) and a_shift_reg_r(0));
   n_bit_is_last <= n_shift_reg_r(0);
 
   alu : entity work.alu(rtl)

--- a/source/rsa_core_control.vhd
+++ b/source/rsa_core_control.vhd
@@ -48,7 +48,7 @@ architecture rtl of rsa_core_control is
 
 begin
 
-  main_process : process (state) is
+  main_process : process (all) is
   begin
 
     state_next <= waiting;

--- a/source/shared/msb_bitscanner.vhd
+++ b/source/shared/msb_bitscanner.vhd
@@ -1,10 +1,11 @@
 library ieee;
   use ieee.std_logic_1164.all;
   use ieee.numeric_std.all;
+  use work.utils.all;
 
 entity msb_bitscanner is
   generic (
-    bit_width : integer := 256
+    bit_width : integer := 8
   );
   port (
     signal_in  : in    std_logic_vector(bit_width - 1 downto 0);
@@ -15,21 +16,9 @@ end entity msb_bitscanner;
 architecture rtl of msb_bitscanner is begin
 
   process (signal_in) is
-
-    variable temp_output : std_logic_vector(bit_width - 1 downto 0) := (others => '0');
-
   begin
 
-    for i in signal_in'reverse_range loop
-
-      if (signal_in(i) = '1') then
-        temp_output(i) := '1';
-        exit;
-      end if;
-
-    end loop;
-
-    signal_out <= temp_output;
+    signal_out <= bitscanner(signal_in);
 
   end process;
 

--- a/source/shared/utils.vhd
+++ b/source/shared/utils.vhd
@@ -6,6 +6,10 @@ package utils is
 
   type alu_opcode_t is (pass, add, sub);
 
+  function bitscanner (
+    a : std_logic_vector
+  ) return std_logic_vector;
+
   -- Calculate Mongomery product
   -- It is assumed that a and b are less than n
   -- and n is an odd number
@@ -40,6 +44,28 @@ end package utils;
 
 package body utils is
 
+  function bitscanner (
+    a : std_logic_vector
+  ) return std_logic_vector
+    is
+
+    variable temp_output : std_logic_vector(a'range) := (others => '0');
+
+  begin
+
+    for i in a'range loop
+
+      if (a(i) = '1') then
+        temp_output(i) := '1';
+        exit;
+      end if;
+
+    end loop;
+
+    return temp_output;
+
+  end function bitscanner;
+
   function monpro (
     a,
     b,
@@ -48,12 +74,14 @@ package body utils is
   return std_logic_vector
   is
 
-    variable u     : std_logic_vector(n'length + 2 downto 0) := (others => '0');
-    variable a_vec : std_logic_vector(n'length - 1 downto 0) := (others => '0');
+    variable u           : std_logic_vector(n'length + 2 downto 0) := (others => '0');
+    variable a_vec       : std_logic_vector(n'length - 1 downto 0) := (others => '0');
+    variable n_shift_reg : std_logic_vector(n'length - 1 downto 0) := (others => '0');
 
   begin
 
-    a_vec := a;
+    a_vec       := a;
+    n_shift_reg := bitscanner(n);
 
     for i in a_vec'reverse_range loop
 
@@ -66,6 +94,10 @@ package body utils is
       end if;
 
       u := std_logic_vector(unsigned(u) / 2);
+
+      if (n_shift_reg(i) = '1') then
+        exit;
+      end if;
 
     end loop;
 

--- a/source/shared/utils.vhd
+++ b/source/shared/utils.vhd
@@ -6,7 +6,9 @@ package utils is
 
   type alu_opcode_t is (pass, add, sub);
 
-  -- Function for calculating Mongomery product
+  -- Calculate Mongomery product
+  -- It is assumed that a and b are less than n
+  -- and n is an odd number
 
   function monpro (
     a,
@@ -14,11 +16,24 @@ package utils is
     n : std_logic_vector
   ) return std_logic_vector;
 
+  -- Calculate modular multiplication
+  -- Sizes of a, b, and n must be within bit_width
+
   function modmul (
     a,
     b,
     n : std_logic_vector;
     bit_width : integer
+  ) return std_logic_vector;
+
+  -- Calculate modular exponentiation
+  -- It is assumed that m and e are less than n
+  -- and that n is an odd number
+
+  function modexp (
+    m,
+    e,
+    n : std_logic_vector
   ) return std_logic_vector;
 
 end package utils;
@@ -89,5 +104,36 @@ package body utils is
     return p(bit_width - 1 downto 0);
 
   end function modmul;
+
+  function modexp (
+    m,
+    e,
+    n : std_logic_vector
+  ) return std_logic_vector
+  is
+
+    variable c : std_logic_vector(n'length - 1 downto 0) := (others => '0');
+
+  begin
+
+    if (e(e'length - 1) = '1') then
+      c := m;
+    else
+      c(0) := '1';
+    end if;
+
+    for i in e'length - 1 downto 0 loop
+
+      c := modmul(c, c, n, n'length);
+
+      if (e(i) = '1') then
+        c := modmul(c, m, n, n'length);
+      end if;
+
+    end loop;
+
+    return c;
+
+  end function modexp;
 
 end package body utils;

--- a/source/shared/utils.vhd
+++ b/source/shared/utils.vhd
@@ -14,6 +14,13 @@ package utils is
     n : std_logic_vector
   ) return std_logic_vector;
 
+  function modmul (
+    a,
+    b,
+    n : std_logic_vector;
+    bit_width : integer
+  ) return std_logic_vector;
+
 end package utils;
 
 package body utils is
@@ -54,5 +61,33 @@ package body utils is
     return u(n'length - 1 downto 0);
 
   end function monpro;
+
+  function modmul (
+    a,
+    b,
+    n : std_logic_vector;
+    bit_width : integer
+  ) return std_logic_vector
+  is
+
+    variable p : std_logic_vector(bit_width + 2 downto 0) := (others => '0');
+
+  begin
+
+    for i in b'range loop
+
+      p := std_logic_vector(shift_left(unsigned(p), 1));
+
+      if (b(i) = '1') then
+        p := std_logic_vector(unsigned(p) + unsigned(a));
+      end if;
+
+      p := std_logic_vector(resize(unsigned(p) mod unsigned(n), p'length));
+
+    end loop;
+
+    return p(bit_width - 1 downto 0);
+
+  end function modmul;
 
 end package body utils;

--- a/source/source.mk
+++ b/source/source.mk
@@ -1,9 +1,15 @@
 alu: utils
+msb_bitscanner: utils
+
 monpro: monpro_datapath monpro_control
-monpro_datapath: alu mux_2to1 bitwise_masker
+monpro_datapath: alu mux_2to1 bitwise_masker msb_bitscanner
 monpro_control: utils
+
 modexp: modexp_datapath modexp_control
 modexp_datapath: monpro mux_3to1 mux_2to1 msb_bitscanner
-modmul_datapath: mux_2to1 bitwise_masker msb_bitscanner
+
 modmul: modmul_control modmul_datapath
+modmul_datapath: mux_2to1 bitwise_masker msb_bitscanner
+modmul_control: utils
+
 rsa_core: rsa_core_control rsa_core_datapath

--- a/testbench/modexp_tb.vhd
+++ b/testbench/modexp_tb.vhd
@@ -1,0 +1,181 @@
+library ieee;
+  use ieee.std_logic_1164.all;
+  use ieee.numeric_std.all;
+
+library uvvm_util;
+  context uvvm_util.uvvm_util_context;
+
+  -- Inclue utils
+  use work.utils.all;
+
+entity modexp_tb is
+  generic (
+    bit_width     : integer := 64;
+    test_set_size : integer := 100;
+    clock_period  : time    := 1 ns
+  );
+end entity modexp_tb;
+
+architecture func of modexp_tb is
+
+  -- Longest possible time to output valid (see state diagrams):
+  -- start states + loop states + end states
+  constant worst_time_to_monpro_valid : integer := (1 + 3 * bit_width + 3);
+  constant worst_time_to_valid        : integer := bit_width +
+                                                   (2 * worst_time_to_monpro_valid + 3) * bit_width +
+                                                   worst_time_to_monpro_valid + 2;
+
+  signal clk_counter : natural;
+
+  signal clk   : std_logic;
+  signal reset : std_logic;
+
+  signal modulus       : std_logic_vector(bit_width - 1 downto 0);
+  signal operand_m_bar : std_logic_vector(bit_width - 1 downto 0);
+  signal operand_x_bar : std_logic_vector(bit_width - 1 downto 0);
+  signal operand_e     : std_logic_vector(bit_width - 1 downto 0);
+
+  signal result : std_logic_vector(bit_width - 1 downto 0);
+
+  -- In/out handshake
+  signal in_valid,  in_ready  : std_logic;
+  signal out_ready, out_valid : std_logic;
+
+begin
+
+  clock_generator(clk, clk_counter, clock_period);
+
+  dut : entity work.modexp
+    generic map (
+      bit_width => bit_width
+    )
+    port map (
+      clk           => clk,
+      reset         => reset,
+      modulus       => modulus,
+      operand_m_bar => operand_m_bar,
+      operand_x_bar => operand_x_bar,
+      operand_e     => operand_e,
+      result        => result,
+      in_valid      => in_valid,
+      in_ready      => in_ready,
+      out_ready     => out_ready,
+      out_valid     => out_valid
+    );
+
+  test_sequencer : process is
+
+    variable expected_result : std_logic_vector(bit_width - 1 downto 0);
+
+    variable test_m, test_e, test_n : std_logic_vector(bit_width downto 0);
+    variable test_m_bar, test_x_bar : std_logic_vector(bit_width downto 0);
+    variable test_r                 : std_logic_vector(bit_width downto 0);
+
+    variable clk_count_at_start : natural;
+
+  begin
+
+    -- Testbench config
+    set_alert_stop_limit(ERROR, 5);
+
+    disable_log_msg(ID_SEQUENCER);
+    disable_log_msg(ID_POS_ACK);
+
+    reset <= '1';
+
+    wait until falling_edge(clk);
+    wait until rising_edge(clk);
+
+    reset <= '0';
+
+    for i in 0 to test_set_size - 1 loop
+
+      log(ID_LOG_HDR, "Running test " & to_string(i));
+
+      while true loop
+
+        test_n := '0' & random(bit_width);
+
+        -- The modulus must be odd
+        if ((unsigned(test_n) mod 2) = 1) then
+          exit;
+        end if;
+
+      end loop;
+
+      while true loop
+
+        test_m := '0' & random(bit_width);
+        test_e := '0' & random(bit_width);
+
+        -- m and e must be less than n
+        if ((unsigned(test_m) < unsigned(test_n)) and (unsigned(test_e) < unsigned(test_n))) then
+          exit;
+        end if;
+
+      end loop;
+
+      -- Transform inputs to Montgomery form
+
+      -- r is 2^(n'length)
+      test_r := std_logic_vector(shift_left(unsigned(bitscanner(test_n)), 1));
+
+      test_m_bar := modmul(test_m, test_r, test_n, bit_width + 1);
+      test_x_bar := modmul(std_logic_vector(to_unsigned(1, bit_width + 1)), test_r, test_n, bit_width + 1);
+
+      expected_result := modexp(test_m, test_e, test_n)(expected_result'range);
+
+      log(
+          "Base          => " & to_string(test_m, HEX, AS_IS, INCL_RADIX) & "\n" &
+          "Exponent      => " & to_string(test_e, HEX, AS_IS, INCL_RADIX) & "\n" &
+          "Modulus       => " & to_string(test_n, HEX, AS_IS, INCL_RADIX) & "\n\n" &
+          
+          "_Base         => " & to_string(test_m_bar, HEX, AS_IS, INCL_RADIX) & "\n" &
+          "_x            => " & to_string(test_x_bar, HEX, AS_IS, INCL_RADIX) & "\n"
+        );
+
+      clk_count_at_start := clk_counter;
+
+      -- Apply tests to DUT
+
+      operand_m_bar <= test_m_bar(operand_m_bar'range);
+      operand_x_bar <= test_x_bar(operand_x_bar'range);
+      operand_e     <= test_e(operand_e'range);
+      modulus       <= test_n(modulus'range);
+
+      -- Perform input handshake
+
+      in_valid <= '1';
+
+      if (in_ready = '0') then
+        wait until rising_edge(in_ready);
+      end if;
+
+      wait until falling_edge(clk);
+      wait until rising_edge(clk);
+
+      in_valid <= '0';
+
+      -- Await completion of calculation
+
+      out_ready <= '1';
+
+      await_value(out_valid, '1', clock_period, worst_time_to_valid * clock_period, "Awaiting output valid");
+
+      wait until rising_edge(clk);
+
+      check_value(result, expected_result, "Checking result");
+
+      out_ready <= '0';
+
+      log("\nClock cycle count: " & to_string(clk_counter - clk_count_at_start));
+
+    end loop;
+
+    report_alert_counters(void);
+
+    std.env.stop;
+
+  end process test_sequencer;
+
+end architecture func;

--- a/testbench/modexp_tb.vhd
+++ b/testbench/modexp_tb.vhd
@@ -20,10 +20,10 @@ architecture func of modexp_tb is
 
   -- Longest possible time to output valid (see state diagrams):
   -- start states + loop states + end states
-  constant worst_time_to_monpro_valid : integer := (1 + 3 * bit_width + 3);
+  constant worst_time_to_monpro_valid : integer := (2 * bit_width + 2);
   constant worst_time_to_valid        : integer := bit_width +
-                                                   (2 * worst_time_to_monpro_valid + 3) * bit_width +
-                                                   worst_time_to_monpro_valid + 2;
+                                                   (2 * worst_time_to_monpro_valid + 1) * bit_width +
+                                                   worst_time_to_monpro_valid + 1;
 
   signal clk_counter : natural;
 
@@ -78,8 +78,8 @@ begin
     -- Testbench config
     set_alert_stop_limit(ERROR, 5);
 
-    disable_log_msg(ID_SEQUENCER);
-    disable_log_msg(ID_POS_ACK);
+    -- disable_log_msg(ID_SEQUENCER);
+    -- disable_log_msg(ID_POS_ACK);
 
     reset <= '1';
 
@@ -130,7 +130,7 @@ begin
           "Exponent      => " & to_string(test_e, HEX, AS_IS, INCL_RADIX) & "\n" &
           "Modulus       => " & to_string(test_n, HEX, AS_IS, INCL_RADIX) & "\n\n" &
           
-          "_Base         => " & to_string(test_m_bar, HEX, AS_IS, INCL_RADIX) & "\n" &
+          "_M            => " & to_string(test_m_bar, HEX, AS_IS, INCL_RADIX) & "\n" &
           "_x            => " & to_string(test_x_bar, HEX, AS_IS, INCL_RADIX) & "\n"
         );
 

--- a/testbench/monpro_tb.vhd
+++ b/testbench/monpro_tb.vhd
@@ -11,7 +11,7 @@ library uvvm_util;
 
 entity monpro_tb is
   generic (
-    bit_width     : integer := 64;
+    bit_width     : integer := 256;
     test_set_size : integer := 100;
     clock_period  : time    := 1 ns
   );
@@ -21,7 +21,7 @@ architecture rtl of monpro_tb is
 
   -- Longest possible time to output valid (see state diagram):
   -- start states + loop states + end states
-  constant worst_time_to_valid : time := (1 + 3 * bit_width + 3) * clock_period;
+  constant worst_time_to_valid : integer := (1 + 3 * bit_width + 3);
 
   signal clk : std_logic;
 
@@ -116,17 +116,15 @@ begin
       wait until rising_edge(clk);
       enable <= '1';
 
-      await_value(output_valid, '1', clock_period, worst_time_to_valid, "Awaiting output valid");
+      await_value(output_valid, '1', clock_period, worst_time_to_valid * clock_period, "Awaiting output valid");
 
       wait until rising_edge(clk);
       enable <= '0';
 
       wait until rising_edge(clk);
-      check_value(result, expected_result, "Result");
+      check_value(result, expected_result, "Checking result");
 
     end loop;
-
-    log(ID_LOG_HDR_LARGE, "End of simulation");
 
     report_alert_counters(void);
 

--- a/testbench/monpro_tb.vhd
+++ b/testbench/monpro_tb.vhd
@@ -61,8 +61,8 @@ begin
     -- Testbench config
     set_alert_stop_limit(ERROR, 5);
 
-    disable_log_msg(ID_SEQUENCER);
-    disable_log_msg(ID_POS_ACK);
+    -- disable_log_msg(ID_SEQUENCER);
+    -- disable_log_msg(ID_POS_ACK);
 
     log(ID_LOG_HDR_LARGE, "Running monpro_tb");
 
@@ -121,7 +121,6 @@ begin
       wait until rising_edge(clk);
       enable <= '0';
 
-      wait until rising_edge(clk);
       check_value(result, expected_result, "Checking result");
 
     end loop;

--- a/testbench/testbench.mk
+++ b/testbench/testbench.mk
@@ -1,2 +1,3 @@
 alu_tb: uvvm_util_context utils alu
 monpro_tb: uvvm_util_context monpro utils
+modexp_tb: uvvm_util_context modexp utils


### PR DESCRIPTION
⚠️ Merge #40 first ⚠️ 

- Improves computation speed by roughly **40%** by removing some states from the modexp and monpro state machines. This is achieved by using Mealy machines instead of Moore machines.